### PR TITLE
Match CD java version/distribution and fix flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
       - name: Test

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <changelist>-SNAPSHOT</changelist>
         <bom>2.277.x</bom>
         <jenkins.version>2.277.4</jenkins.version>
-        <java.level>8</java.level>
+        <java.level>11</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
 

--- a/src/test/java/io/jenkins/plugins/BuildAPITest.java
+++ b/src/test/java/io/jenkins/plugins/BuildAPITest.java
@@ -301,7 +301,7 @@ public class BuildAPITest {
   private void assertBuildInfoOkay(Job job, BuildExt buildExt, String jobNumber) {
     Assert.assertEquals("TestJob #" + jobNumber, buildExt.getFullName());
     Assert.assertEquals("SUCCESS", buildExt.getResult());
-    Assert.assertTrue(buildExt.getDuration() > 0);
+    Assert.assertTrue(buildExt.getDuration() >= 0);
     Assert.assertTrue(buildExt.getStartTimeMillis() > startTime);
     Assert.assertEquals(jobNumber, buildExt.getId());
     Assert.assertTrue(buildExt.getStartTimeMillis() > buildExt.getQueueTimeMillis());

--- a/src/test/java/io/jenkins/plugins/BuildAPITest.java
+++ b/src/test/java/io/jenkins/plugins/BuildAPITest.java
@@ -304,7 +304,7 @@ public class BuildAPITest {
     Assert.assertTrue(buildExt.getDuration() >= 0);
     Assert.assertTrue(buildExt.getStartTimeMillis() > startTime);
     Assert.assertEquals(jobNumber, buildExt.getId());
-    Assert.assertTrue(buildExt.getStartTimeMillis() > buildExt.getQueueTimeMillis());
+    Assert.assertTrue(buildExt.getStartTimeMillis() >= buildExt.getQueueTimeMillis());
     Assert.assertEquals("", buildExt.getBuiltOn());
   }
 


### PR DESCRIPTION
This change fixes a flaky test where the duration of some test builds was being set to 0 instead of the expected 'greater than 0'. Zero is a valid build duration, so we should not be expecting greater than zero.

This change also aligns the CI java distribution with the CD distribution and sets the java level in the pom to 11 to match both the CI and CD

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
